### PR TITLE
docs: :memo: Update Code of Conduct link to point to the official Microsoft page

### DIFF
--- a/organization/registration-page-draft.md
+++ b/organization/registration-page-draft.md
@@ -41,7 +41,7 @@ Wrap up the session and leave time for networking.
 ---
 ## 📜 Code of Conduct
 
-We are committed to fostering an inclusive and welcoming environment for all participants. Please review our [Code of Conduct](#) before attending.  
+We are committed to fostering an inclusive and welcoming environment for all participants. Please review our [Code of Conduct](https://www.microsoft.com/en-us/events/code-of-conduct) before attending.  
 
 ## 📍 How to Get There
 


### PR DESCRIPTION
Most VS Code Dev Days locations are hosted at Microsoft offices, so it makes sense to link directly to the official Microsoft Events Code of Conduct as a default. This ensures consistency and clarity across event descriptions. Signed-off-by: Augustine Correa <augcor@gmail.com>